### PR TITLE
Feature/p2022 1332 create mock repository for categories

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,14 +37,16 @@ android {
 dependencies {
 
     implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.5.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.5'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.4.1'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.4.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1'
+
 }

--- a/app/src/main/assets/products.json
+++ b/app/src/main/assets/products.json
@@ -88,5 +88,14 @@
     "keywords": "LG, 4k, smart",
     "category": "TV",
     "imageUrl": "www.image.com/86NANO916PA"
+  },
+  {
+    "name": "OnePlus 5T",
+    "description": "Android-based smartphone.",
+    "priceGross": 840.00,
+    "tax": 252.00,
+    "keywords": "One Plus, SmartPhone",
+    "category": "Phone",
+    "imageUrl": "www.image.com/86NANO916PA"
   }
 ]

--- a/app/src/main/java/com/intive/patronage22/lublin/repository/CategoryRepository.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/repository/CategoryRepository.kt
@@ -1,5 +1,5 @@
 package com.intive.patronage22.lublin.repository
 
 interface CategoryRepository {
-    suspend fun getCategories(): Set<String>
+    suspend fun getCategories(): List<String>
 }

--- a/app/src/main/java/com/intive/patronage22/lublin/repository/CategoryRepository.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/repository/CategoryRepository.kt
@@ -1,0 +1,5 @@
+package com.intive.patronage22.lublin.repository
+
+interface CategoryRepository {
+    suspend fun getCategories(): Set<String>
+}

--- a/app/src/main/java/com/intive/patronage22/lublin/repository/CategoryRepositoryMock.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/repository/CategoryRepositoryMock.kt
@@ -4,8 +4,7 @@ class CategoryRepositoryMock(
     private val productRepository: ProductRepository
 ) : CategoryRepository {
 
-    override suspend fun getCategories(): Set<String> {
+    override suspend fun getCategories(): List<String> {
         return productRepository.getProductList().map { it.category }
-            .toSet()
     }
 }

--- a/app/src/main/java/com/intive/patronage22/lublin/repository/CategoryRepositoryMock.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/repository/CategoryRepositoryMock.kt
@@ -1,0 +1,11 @@
+package com.intive.patronage22.lublin.repository
+
+class CategoryRepositoryMock(
+    private val productRepository: ProductRepository
+) : CategoryRepository {
+
+    override suspend fun getCategories(): Set<String> {
+        return productRepository.getProductList().map { it.category }
+            .toSet()
+    }
+}

--- a/app/src/main/java/com/intive/patronage22/lublin/repository/JsonFetcher.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/repository/JsonFetcher.kt
@@ -5,9 +5,10 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.intive.patronage22.lublin.repository.model.ProductAPI
 
+private val gson = Gson()
+
 class JsonFetcher {
     fun getProductAPIList(context: Context, fileName: String): List<ProductAPI> {
-        val gson = Gson()
         val listProductAPIType = object : TypeToken<List<ProductAPI>>() {}.type
         val jsonString = context.assets.open(fileName).bufferedReader().use { it.readText() }
         return gson.fromJson(jsonString, listProductAPIType)

--- a/app/src/main/java/com/intive/patronage22/lublin/repository/mapper/ProductListMapper.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/repository/mapper/ProductListMapper.kt
@@ -10,7 +10,7 @@ class ProductListMapper : ListMapper {
         val productList: MutableList<Product> = mutableListOf()
 
         input.forEach {
-            productList.add(Product(it.name, it.priceGross))
+            productList.add(Product(it.name, it.priceGross, it.category))
         }
 
         return productList

--- a/app/src/main/java/com/intive/patronage22/lublin/repository/model/Product.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/repository/model/Product.kt
@@ -2,5 +2,6 @@ package com.intive.patronage22.lublin.repository.model
 
 data class Product(
     val name: String,
-    val price: Double
+    val price: Double,
+    val category: String
 )

--- a/app/src/main/java/com/intive/patronage22/lublin/repository/model/categories/CategoriesViewModel.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/repository/model/categories/CategoriesViewModel.kt
@@ -1,0 +1,16 @@
+package com.intive.patronage22.lublin.repository.model.categories
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.intive.patronage22.lublin.repository.CategoryRepository
+import kotlinx.coroutines.launch
+
+class CategoriesViewModel(categoryRepository: CategoryRepository) : ViewModel() {
+   lateinit var categories: Set<String>
+
+    init {
+        viewModelScope.launch {
+            categories = categoryRepository.getCategories()
+        }
+    }
+}

--- a/app/src/main/java/com/intive/patronage22/lublin/repository/model/categories/CategoriesViewModel.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/repository/model/categories/CategoriesViewModel.kt
@@ -1,16 +1,26 @@
 package com.intive.patronage22.lublin.repository.model.categories
 
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.intive.patronage22.lublin.repository.CategoryRepository
 import kotlinx.coroutines.launch
 
-class CategoriesViewModel(categoryRepository: CategoryRepository) : ViewModel() {
-   lateinit var categories: Set<String>
+class CategoriesViewModel(private val categoryRepository: CategoryRepository) : ViewModel() {
 
-    init {
-        viewModelScope.launch {
-            categories = categoryRepository.getCategories()
+    val categories
+        get(): MutableLiveData<List<String>> {
+            val result = MutableLiveData<List<String>>()
+            viewModelScope.launch {
+                result.postValue(
+                    try {
+                        categoryRepository.getCategories().distinct()
+                    } catch (exception: Exception) {
+                        emptyList() // TODO: handle exception
+                    }
+                )
+            }
+            return result
         }
-    }
+
 }

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/categories/CategoriesFragment.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/categories/CategoriesFragment.kt
@@ -1,11 +1,64 @@
 package com.intive.patronage22.lublin.screens.categories
 
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.BaseAdapter
+import android.widget.Button
+import android.widget.ListView
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.intive.patronage22.lublin.R
+import com.intive.patronage22.lublin.repository.CategoryRepositoryMock
+import com.intive.patronage22.lublin.repository.ProductRepositoryMock
 import com.intive.patronage22.lublin.repository.model.categories.CategoriesViewModel
 
 class CategoriesFragment : Fragment(R.layout.fragment_categories) {
     private lateinit var viewModel: CategoriesViewModel
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        viewModel = CategoriesViewModel(
+            CategoryRepositoryMock(
+                ProductRepositoryMock(requireContext())
+            )
+        )
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_categories, container, false)
+        val categoriesListView = view.findViewById<ListView>(R.id.listCategories)
+        val categories = viewModel.categories.toList()
+//        val categories = (0..100).map {"category-$it"} // check scrolling
+        categoriesListView.adapter = object : BaseAdapter() {
+            override fun getCount() = categories.size
+
+            override fun getItem(position: Int) = categories[position]
+
+            override fun getItemId(position: Int) = position.toLong()
+
+            override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
+                Log.d("inflating", "row ${categories[position]}")
+                val row = layoutInflater.inflate(R.layout.category_list_row, null)
+                val rowButton = row.findViewById<Button>(R.id.categoriesListButton)
+
+                rowButton.text = categories[position]
+                rowButton.setOnClickListener {
+                    Toast.makeText(requireContext(), "Not Implemented", Toast.LENGTH_SHORT).show()
+                }
+                return row
+            }
+
+        }
+        return view
+    }
 
 
 }

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/categories/CategoriesFragment.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/categories/CategoriesFragment.kt
@@ -2,7 +2,10 @@ package com.intive.patronage22.lublin.screens.categories
 
 import androidx.fragment.app.Fragment
 import com.intive.patronage22.lublin.R
+import com.intive.patronage22.lublin.repository.model.categories.CategoriesViewModel
 
 class CategoriesFragment : Fragment(R.layout.fragment_categories) {
+    private lateinit var viewModel: CategoriesViewModel
+
 
 }

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/categories/CategoriesFragment.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/categories/CategoriesFragment.kt
@@ -10,6 +10,7 @@ import android.widget.Button
 import android.widget.ListView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.RecyclerView
 import com.intive.patronage22.lublin.R
 import com.intive.patronage22.lublin.repository.CategoryRepositoryMock
 import com.intive.patronage22.lublin.repository.ProductRepositoryMock
@@ -34,29 +35,10 @@ class CategoriesFragment : Fragment(R.layout.fragment_categories) {
         savedInstanceState: Bundle?
     ): View? {
         val view = inflater.inflate(R.layout.fragment_categories, container, false)
-        val categoriesListView = view.findViewById<ListView>(R.id.listCategories)
+        val categoriesListView = view.findViewById<RecyclerView>(R.id.listCategories)
         val categories = viewModel.categories.toList()
 //        val categories = (0..100).map {"category-$it"} // check scrolling
-        categoriesListView.adapter = object : BaseAdapter() {
-            override fun getCount() = categories.size
-
-            override fun getItem(position: Int) = categories[position]
-
-            override fun getItemId(position: Int) = position.toLong()
-
-            override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
-                Log.d("inflating", "row ${categories[position]}")
-                val row = layoutInflater.inflate(R.layout.category_list_row, null)
-                val rowButton = row.findViewById<Button>(R.id.categoriesListButton)
-
-                rowButton.text = categories[position]
-                rowButton.setOnClickListener {
-                    Toast.makeText(requireContext(), "Not Implemented", Toast.LENGTH_SHORT).show()
-                }
-                return row
-            }
-
-        }
+        categoriesListView.adapter = CategoriesListAdapter(requireContext(), categories)
         return view
     }
 

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/categories/CategoriesFragment.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/categories/CategoriesFragment.kt
@@ -1,14 +1,9 @@
 package com.intive.patronage22.lublin.screens.categories
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.BaseAdapter
-import android.widget.Button
-import android.widget.ListView
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
 import com.intive.patronage22.lublin.R
@@ -36,9 +31,9 @@ class CategoriesFragment : Fragment(R.layout.fragment_categories) {
     ): View? {
         val view = inflater.inflate(R.layout.fragment_categories, container, false)
         val categoriesListView = view.findViewById<RecyclerView>(R.id.listCategories)
-        val categories = viewModel.categories.toList()
-//        val categories = (0..100).map {"category-$it"} // check scrolling
-        categoriesListView.adapter = CategoriesListAdapter(requireContext(), categories)
+        viewModel.categories.observe(viewLifecycleOwner) { categories ->
+            categoriesListView.adapter = CategoriesListAdapter(requireContext(), categories)
+        }
         return view
     }
 

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/categories/CategoriesListAdapter.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/categories/CategoriesListAdapter.kt
@@ -1,0 +1,42 @@
+package com.intive.patronage22.lublin.screens.categories
+
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import android.widget.Toast
+import androidx.recyclerview.widget.RecyclerView
+import com.intive.patronage22.lublin.R
+
+class CategoriesListAdapter(private val context: Context, private val categories: List<String>) :
+    RecyclerView.Adapter<CategoriesListAdapter.ViewHolder>() {
+
+    class ViewHolder(private val context: Context, itemView: View) :
+        RecyclerView.ViewHolder(itemView) {
+        private val categoryTextView: TextView = itemView.findViewById(R.id.categoriesListText)
+
+        fun bind(category: String) {
+            categoryTextView.text = category
+            categoryTextView.setOnClickListener {
+                Toast.makeText(context, "$category Not Implemented", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.category_list_row, parent, false)
+
+        return ViewHolder(context, view)
+    }
+
+    override fun getItemCount(): Int {
+        return categories.size
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(categories[position])
+    }
+}

--- a/app/src/main/res/layout/category_list_row.xml
+++ b/app/src/main/res/layout/category_list_row.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/categoriesListButton" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/category_list_row.xml
+++ b/app/src/main/res/layout/category_list_row.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <Button
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:id="@+id/categoriesListButton" />
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/categoriesListText"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_categories.xml
+++ b/app/src/main/res/layout/fragment_categories.xml
@@ -7,11 +7,10 @@
     android:layout_height="match_parent"
     tools:context=".screens.categories.CategoriesFragment">
 
-    <TextView
-        android:id="@+id/tvCategories"
+    <ListView
+        android:id="@+id/listCategories"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/categories"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_categories.xml
+++ b/app/src/main/res/layout/fragment_categories.xml
@@ -7,10 +7,11 @@
     android:layout_height="match_parent"
     tools:context=".screens.categories.CategoriesFragment">
 
-    <ListView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/listCategories"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
# Ticket number
[P2022-1332](https://tracker.intive.com/jira/browse/P2022-1332)
## PROBLEM
Create mock repository for categories. 
### **AC:**
Categories list is displayed and scrollable (create mock repository date similarly to products list)
Each item contains title
Upon clicking the item toast message appears with message "Not Implemented"

## SOLUTION
I created a category repository by adding an argument to the products and the list storing them _(ProductListMapper.kt)._
I also created the _CategoryRepository.kt_ and _CategoryRepositoryMock.kt_ files for this purpose.
Displaying categories is in the form of a button that I described in the file (_category_list_row.xml_). I added an adapter to the category fragment (_CategoriesFragment.kt_) that displays a list of categories (buttons) and responses to clicking in the form of **toast.makeText**. I have added _CategoriesViewModel.kt_ to store and manage UI-related data in a lifecycle-conscious way.

### I described the details in the commits.

## SCREENSHOTS
Before:
![image](https://user-images.githubusercontent.com/32538721/156011786-f551dca3-0672-470b-95b3-323f77272f90.png)
After:
![image](https://user-images.githubusercontent.com/32538721/156010818-656b2a51-fc83-4bdd-a8b2-03628f704933.png)
For test purposes for scrolling:
![image](https://user-images.githubusercontent.com/32538721/156011599-e36d8377-e612-4acf-8094-b7cf5a6314d4.png)



## SIDE NOTES
Thread-safe GSON is moved out of JsonFetcher class so it's not created every time. Additionally updated dependencies. 
I leave comment **// val categories = (0..100).map {"category-$it"}** in _CategoriesFragment.kt_ to check if scrolling works. Look screen above. Additionally, I removed _TextView_ because it was not needed for this current task.