### PR TITLE
P2022-630-Create-details-screen-for-given-product

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
         applicationId "com.intive.patronage22.lublin"
         minSdk 21
         targetSdk 32
-        versionCode runId.toInteger() + 1
+        versionCode 1
         versionName "1.0"
 
         buildConfigField "String", "CI", "\"${isCI}\""
@@ -48,8 +48,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.4.1'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.4.1'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.4.2'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.4.2'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,20 +4,26 @@
     package="com.intive.patronage22.lublin">
 
     <uses-permission android:name="android.permission.INTERNET" />
+
     <application
-        android:usesCleartextTraffic="true"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Patronage2022"
+        android:usesCleartextTraffic="true"
         tools:targetApi="m">
+        <activity
+            android:name=".screens.productsdetails.ProductDetailsActivity"
+            android:exported="false"
+            android:screenOrientation="portrait"
+            tools:ignore="LockedOrientationActivity" />
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.Patronage2022.NoActionBar"
             android:screenOrientation="portrait"
+            android:theme="@style/Theme.Patronage2022.NoActionBar"
             tools:ignore="LockedOrientationActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         <activity
             android:name=".screens.productsdetails.ProductDetailsActivity"
             android:exported="false"
+            android:parentActivityName=".MainActivity"
             android:screenOrientation="portrait"
             tools:ignore="LockedOrientationActivity" />
         <activity

--- a/app/src/main/java/com/intive/patronage22/lublin/Constants.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/Constants.kt
@@ -1,3 +1,4 @@
 package com.intive.patronage22.lublin
 
 const val URL = "http://proxy-patronageapi.bsolutions.usermd.net/"
+const val productExtraName = "product_data"

--- a/app/src/main/java/com/intive/patronage22/lublin/Constants.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/Constants.kt
@@ -1,4 +1,3 @@
 package com.intive.patronage22.lublin
 
 const val URL = "http://proxy-patronageapi.bsolutions.usermd.net/"
-const val productExtraName = "product_data"

--- a/app/src/main/java/com/intive/patronage22/lublin/Constants.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/Constants.kt
@@ -1,0 +1,3 @@
+package com.intive.patronage22.lublin
+
+const val URL = "http://proxy-patronageapi.bsolutions.usermd.net/"

--- a/app/src/main/java/com/intive/patronage22/lublin/data/api/PatronageService.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/data/api/PatronageService.kt
@@ -5,6 +5,6 @@ import retrofit2.http.GET
 
 
 interface PatronageService {
-    @GET("products/getAllProductsExternal")
+    @GET("products/getAllPublishedProductsExternal")
     suspend fun getAllProducts(): List<ProductApi>
 }

--- a/app/src/main/java/com/intive/patronage22/lublin/repository/model/ProductApi.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/repository/model/ProductApi.kt
@@ -27,7 +27,9 @@ data class ProductApi(
     @SerializedName("photos")
     val photosList: List<PhotoApi>,
     @SerializedName("category")
-    val category: String?
+    val category: String?,
+    @SerializedName("categoryId")
+    val categoryId: Int
 ) : Parcelable
 @Parcelize
 data class PhotoApi(

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/home/HomeFragment.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/home/HomeFragment.kt
@@ -12,14 +12,14 @@ import androidx.recyclerview.widget.RecyclerView
 import com.intive.patronage22.lublin.R
 import com.intive.patronage22.lublin.data.api.RetrofitBuilder
 import com.intive.patronage22.lublin.databinding.FragmentHomeBinding
-import com.intive.patronage22.lublin.ui.base.ProductViewModel
+import com.intive.patronage22.lublin.ui.base.ProductsViewModel
 import com.intive.patronage22.lublin.ui.base.ViewModelFactory
 import com.intive.patronage22.lublin.utils.Status
 
 class HomeFragment : Fragment(R.layout.fragment_home) {
 
     private val factory = ViewModelFactory(RetrofitBuilder.apiService)
-    private val viewModel: ProductViewModel by viewModels { factory }
+    private val viewModel: ProductsViewModel by viewModels { factory }
     private lateinit var adapter: HomeListAdapter
 
     override fun onCreateView(
@@ -28,7 +28,7 @@ class HomeFragment : Fragment(R.layout.fragment_home) {
         savedInstanceState: Bundle?
     ): View {
         val binding = FragmentHomeBinding.inflate(inflater, container, false)
-        val adapter = HomeListAdapter()
+        val adapter = HomeListAdapter(viewModel)
         binding.listProducts.adapter = adapter
         this.adapter = adapter
         setupObservers(binding.listProducts)

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/home/HomeListAdapter.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/home/HomeListAdapter.kt
@@ -9,11 +9,11 @@ import com.bumptech.glide.Glide
 import com.intive.patronage22.lublin.R
 import com.intive.patronage22.lublin.URL
 import com.intive.patronage22.lublin.databinding.HomeSingleItemBinding
-import com.intive.patronage22.lublin.productExtraName
 import com.intive.patronage22.lublin.repository.model.Product
 import com.intive.patronage22.lublin.screens.productsdetails.ProductDetailsActivity
+import com.intive.patronage22.lublin.ui.base.ProductsViewModel
 
-class HomeListAdapter :
+class HomeListAdapter(private val productsViewModel: ProductsViewModel) :
     RecyclerView.Adapter<HomeListAdapter.ViewHolder>() {
 
     private var products: List<Product> = emptyList()
@@ -23,11 +23,12 @@ class HomeListAdapter :
     }
 
     class ViewHolder(
-        private val binding: HomeSingleItemBinding
+        private val productsViewModel: ProductsViewModel,
+        private val binding: HomeSingleItemBinding,
     ) : RecyclerView.ViewHolder(binding.root) {
         fun bind(product: Product) {
             binding.productsListTitle.text = product.title
-            binding.productsListPrice.text = product.price.toString()
+            binding.productsListPrice.text = "${binding.root.context.resources.getString(R.string.price_prefix)} ${product.price}"
             Glide.with(binding.root)
                 .load(URL + product.mainPhotoUrl)
                 .placeholder(R.drawable.image_placeholder)
@@ -35,7 +36,7 @@ class HomeListAdapter :
                 .into(binding.productImage)
             binding.root.setOnClickListener {
                 val intent = Intent(binding.root.context, ProductDetailsActivity::class.java)
-                intent.putExtra(productExtraName, product)
+                productsViewModel.pack(intent, product)
                 startActivity(binding.root.context, intent, null)
             }
         }
@@ -48,7 +49,7 @@ class HomeListAdapter :
             false
         )
 
-        return ViewHolder(binding)
+        return ViewHolder(productsViewModel,binding)
     }
 
     override fun getItemCount(): Int {

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/home/HomeListAdapter.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/home/HomeListAdapter.kt
@@ -9,6 +9,7 @@ import com.bumptech.glide.Glide
 import com.intive.patronage22.lublin.R
 import com.intive.patronage22.lublin.URL
 import com.intive.patronage22.lublin.databinding.HomeSingleItemBinding
+import com.intive.patronage22.lublin.productExtraName
 import com.intive.patronage22.lublin.repository.model.Product
 import com.intive.patronage22.lublin.screens.productsdetails.ProductDetailsActivity
 
@@ -34,6 +35,7 @@ class HomeListAdapter :
                 .into(binding.productImage)
             binding.root.setOnClickListener {
                 val intent = Intent(binding.root.context, ProductDetailsActivity::class.java)
+                intent.putExtra(productExtraName, product)
                 startActivity(binding.root.context, intent, null)
             }
         }

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/home/HomeListAdapter.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/home/HomeListAdapter.kt
@@ -1,12 +1,16 @@
 package com.intive.patronage22.lublin.screens.home
 
+import android.content.Intent
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat.startActivity
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.intive.patronage22.lublin.R
+import com.intive.patronage22.lublin.URL
 import com.intive.patronage22.lublin.databinding.HomeSingleItemBinding
 import com.intive.patronage22.lublin.repository.model.Product
+import com.intive.patronage22.lublin.screens.productsdetails.ProductDetailsActivity
 
 class HomeListAdapter :
     RecyclerView.Adapter<HomeListAdapter.ViewHolder>() {
@@ -18,17 +22,20 @@ class HomeListAdapter :
     }
 
     class ViewHolder(
-        private val binding: HomeSingleItemBinding,
-        private val urlString: String = "http://proxy-patronageapi.bsolutions.usermd.net/"
+        private val binding: HomeSingleItemBinding
     ) : RecyclerView.ViewHolder(binding.root) {
         fun bind(product: Product) {
             binding.productsListTitle.text = product.title
             binding.productsListPrice.text = product.price.toString()
             Glide.with(binding.root)
-                .load(urlString + product.mainPhotoUrl)
+                .load(URL + product.mainPhotoUrl)
                 .placeholder(R.drawable.image_placeholder)
                 .fitCenter()
                 .into(binding.productImage)
+            binding.root.setOnClickListener {
+                val intent = Intent(binding.root.context, ProductDetailsActivity::class.java)
+                startActivity(binding.root.context, intent, null)
+            }
         }
     }
 

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/home/HomeListAdapter.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/home/HomeListAdapter.kt
@@ -28,7 +28,7 @@ class HomeListAdapter(private val productsViewModel: ProductsViewModel) :
     ) : RecyclerView.ViewHolder(binding.root) {
         fun bind(product: Product) {
             binding.productsListTitle.text = product.title
-            binding.productsListPrice.text = "${binding.root.context.resources.getString(R.string.price_prefix)} ${product.price}"
+            binding.productsListPrice.text = binding.root.context.resources.getString(R.string.product_price, product.price)
             Glide.with(binding.root)
                 .load(URL + product.mainPhotoUrl)
                 .placeholder(R.drawable.image_placeholder)

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/productsdetails/ProductDetailsActivity.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/productsdetails/ProductDetailsActivity.kt
@@ -1,12 +1,15 @@
 package com.intive.patronage22.lublin.screens.productsdetails
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import com.intive.patronage22.lublin.R
+import com.intive.patronage22.lublin.productExtraName
+import com.intive.patronage22.lublin.repository.model.Product
 
 class ProductDetailsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_product_details)
+        val product: Product? = intent.getParcelableExtra(productExtraName)
     }
 }

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/productsdetails/ProductDetailsActivity.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/productsdetails/ProductDetailsActivity.kt
@@ -1,14 +1,21 @@
 package com.intive.patronage22.lublin.screens.productsdetails
 
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import com.bumptech.glide.Glide
 import com.intive.patronage22.lublin.R
-import com.intive.patronage22.lublin.databinding.ActivityMainBinding
+import com.intive.patronage22.lublin.URL
+import com.intive.patronage22.lublin.data.api.RetrofitBuilder
 import com.intive.patronage22.lublin.databinding.ActivityProductDetailsBinding
-import com.intive.patronage22.lublin.productExtraName
 import com.intive.patronage22.lublin.repository.model.Product
+import com.intive.patronage22.lublin.ui.base.ProductsViewModel
+import com.intive.patronage22.lublin.ui.base.ViewModelFactory
 
 class ProductDetailsActivity : AppCompatActivity() {
+
+    private val factory = ViewModelFactory(RetrofitBuilder.apiService)
+    private val viewModel: ProductsViewModel by viewModels { factory }
 
     private lateinit var binding: ActivityProductDetailsBinding
 
@@ -16,6 +23,15 @@ class ProductDetailsActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityProductDetailsBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        val product: Product? = intent.getParcelableExtra(productExtraName)
+
+        val product = viewModel.getProductFrom(intent)!!
+        Glide.with(binding.root)
+            .load(URL + product.mainPhotoUrl)
+            .placeholder(R.drawable.image_placeholder)
+            .fitCenter()
+            .into(binding.productImage)
+        binding.productName.text = product.title
+        binding.productPrice.text = "${binding.root.context.resources.getString(R.string.price_prefix)} ${product.price}"
+        binding.productDescription.text = product.description
     }
 }

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/productsdetails/ProductDetailsActivity.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/productsdetails/ProductDetailsActivity.kt
@@ -31,7 +31,7 @@ class ProductDetailsActivity : AppCompatActivity() {
             .fitCenter()
             .into(binding.productImage)
         binding.productName.text = product.title
-        binding.productPrice.text = "${binding.root.context.resources.getString(R.string.price_prefix)} ${product.price}"
+        binding.productPrice.text = binding.root.context.resources.getString(R.string.product_price, product.price)
         binding.productDescription.text = product.description
     }
 }

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/productsdetails/ProductDetailsActivity.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/productsdetails/ProductDetailsActivity.kt
@@ -1,0 +1,12 @@
+package com.intive.patronage22.lublin.screens.productsdetails
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import com.intive.patronage22.lublin.R
+
+class ProductDetailsActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_product_details)
+    }
+}

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/productsdetails/ProductDetailsActivity.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/productsdetails/ProductDetailsActivity.kt
@@ -3,13 +3,19 @@ package com.intive.patronage22.lublin.screens.productsdetails
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.intive.patronage22.lublin.R
+import com.intive.patronage22.lublin.databinding.ActivityMainBinding
+import com.intive.patronage22.lublin.databinding.ActivityProductDetailsBinding
 import com.intive.patronage22.lublin.productExtraName
 import com.intive.patronage22.lublin.repository.model.Product
 
 class ProductDetailsActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityProductDetailsBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_product_details)
+        binding = ActivityProductDetailsBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         val product: Product? = intent.getParcelableExtra(productExtraName)
     }
 }

--- a/app/src/main/java/com/intive/patronage22/lublin/ui/base/ProductsViewModel.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/ui/base/ProductsViewModel.kt
@@ -1,13 +1,17 @@
 package com.intive.patronage22.lublin.ui.base
 
+import android.content.Intent
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.liveData
 import com.intive.patronage22.lublin.data.repository.ProductRepository
+import com.intive.patronage22.lublin.repository.model.Product
 import com.intive.patronage22.lublin.utils.Resource
 import kotlinx.coroutines.Dispatchers
 
-class ProductViewModel(private val productRepository: ProductRepository) : ViewModel() {
+private const val productExtraName = "single_product_data"
+
+class ProductsViewModel(private val productRepository: ProductRepository) : ViewModel() {
 
     fun getAllProducts() = liveData(Dispatchers.IO) {
         emit(Resource.loading(data = null))
@@ -18,4 +22,9 @@ class ProductViewModel(private val productRepository: ProductRepository) : ViewM
             emit(Resource.error(data = null, message = exception.message ?: "Error Occurred!"))
         }
     }
+
+    fun getProductFrom(intent:Intent): Product? = intent.getParcelableExtra(productExtraName)
+
+    fun pack(intent:Intent, product:Product) = intent.putExtra(productExtraName, product)
+
 }

--- a/app/src/main/java/com/intive/patronage22/lublin/ui/base/ViewModelFactory.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/ui/base/ViewModelFactory.kt
@@ -10,8 +10,8 @@ class ViewModelFactory(private val patronageService: PatronageService) : ViewMod
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        if (modelClass.isAssignableFrom(ProductViewModel::class.java)) {
-            return ProductViewModel(ProductRepository(patronageService)) as T
+        if (modelClass.isAssignableFrom(ProductsViewModel::class.java)) {
+            return ProductsViewModel(ProductRepository(patronageService)) as T
         } else if (modelClass.isAssignableFrom(CategoriesViewModel::class.java)) {
             return CategoriesViewModel(CategoryRepository(
                 ProductRepository(patronageService)

--- a/app/src/main/res/layout/activity_product_details.xml
+++ b/app/src/main/res/layout/activity_product_details.xml
@@ -1,8 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".screens.productsdetails.ProductDetailsActivity">
+
+    <ImageView
+        android:id="@+id/productImage"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true"
+        android:contentDescription="@string/product_image_description"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@android:drawable/btn_star" />
+
+    <TextView
+        android:id="@+id/productName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="25dp"
+        android:layout_marginTop="30dp"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/productImage" />
+
+    <TextView
+        android:id="@+id/productPrice"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="25dp"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/productName" />
+
+    <TextView
+        android:id="@+id/productDescription"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="30dp"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/productPrice" />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_product_details.xml
+++ b/app/src/main/res/layout/activity_product_details.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".screens.productsdetails.ProductDetailsActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,5 +20,6 @@
     <string name="about">About</string>
     <string name="hello_hello">Hello Hello</string>
     <string name="product_image_description">Product image</string>
+    <string name="price_prefix">Price: %s</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,6 @@
     <string name="about">About</string>
     <string name="hello_hello">Hello Hello</string>
     <string name="product_image_description">Product image</string>
-    <string name="price_prefix">Price: %s</string>
+    <string name="product_price">Price: %d</string>
 
 </resources>


### PR DESCRIPTION
# [P2022-630](https://tracker.intive.com/jira/browse/P2022-630)

## PROBLEM
As a user, I would like to have an option to review mode details for the given product.

# **AC:**

Upon clicking the item on the product list separate screen should be opened
Product screen contains: name, price, description, image
Bottom Navigation Bar shouldn't be visible
TECH NOTE:

New screen should be separate activity

Pass id of the product by navigation component (https://developer.android.com/guide/navigation/navigation-pass-data)

Use ViewModel from business logic

## SOLUTION

## SCREENSHOTS
![image](https://user-images.githubusercontent.com/32538721/164983992-fd5032ee-2c26-4cc4-99dd-51e5b00226d6.png)

## SIDE NOTES

