### PR TITLE
Feature/p2022 2208 add UI to fragment

### DIFF
--- a/app/src/main/java/com/intive/patronage22/lublin/screens/login/LoginActivity.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/login/LoginActivity.kt
@@ -1,7 +1,10 @@
 package com.intive.patronage22.lublin.screens.login
 
+import android.content.Intent
 import android.os.Bundle
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import com.intive.patronage22.lublin.MainActivity
 import com.intive.patronage22.lublin.databinding.FragmentLoginBinding
 
 class LoginActivity : AppCompatActivity() {
@@ -13,5 +16,14 @@ class LoginActivity : AppCompatActivity() {
 
         binding = FragmentLoginBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        binding.buttonLogin.setOnClickListener {
+            val intent = Intent(this, MainActivity::class.java)
+            startActivity(intent)
+        }
+
+        binding.registerButton.setOnClickListener {
+            Toast.makeText(this, "Registering users not supported", Toast.LENGTH_SHORT).show()
+        }
     }
 }

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -2,17 +2,51 @@
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/testText"
-        android:layout_width="wrap_content"
+    <Button
+        android:id="@+id/registerButton"
+        android:layout_width="200sp"
         android:layout_height="wrap_content"
-        android:text="Test Login Screen"
+        android:text="@string/register_button_text"
+        app:layout_constraintEnd_toEndOf="@+id/buttonLogin"
+        app:layout_constraintStart_toStartOf="@+id/buttonLogin"
+        app:layout_constraintTop_toBottomOf="@+id/buttonLogin" />
+
+    <EditText
+        android:id="@+id/editTextUsername"
+        android:layout_width="200sp"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:hint="@string/username_hint"
+        android:inputType="textPersonName"
+        android:minHeight="48dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <EditText
+        android:id="@+id/editTextPassword"
+        android:layout_width="200sp"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:hint="@string/password_hint"
+        android:minHeight="48dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/editTextUsername" />
+
+    <Button
+        android:id="@+id/buttonLogin"
+        android:layout_width="200sp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="45dp"
+        android:text="@string/login_button_text"
+        app:layout_constraintEnd_toEndOf="@+id/editTextPassword"
+        app:layout_constraintStart_toStartOf="@+id/editTextPassword"
+        app:layout_constraintTop_toBottomOf="@+id/editTextPassword" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,5 +21,10 @@
     <string name="hello_hello">Hello Hello</string>
     <string name="product_image_description">Product image</string>
     <string name="product_price">Price: %d</string>
+    <!-- Login screen -->
+    <string name="username_hint">Username</string>
+    <string name="password_hint">Password</string>
+    <string name="login_button_text">Login</string>
+    <string name="register_button_text">Register</string>
 
 </resources>


### PR DESCRIPTION
# [P2022-2208](https://tracker.intive.com/jira/browse/P2022-2208)

## PROBLEM
Add UI to fragment.
AC:

- screen should contain two edit text fields and two buttons
- edit texts should be placed in the middle of the screen, one above the other
- edit texts should have same width
- upper edit text should contain hint "Username"
- lower edit text should contain hint "Password"
- buttons should be placed below edit texts
- buttons width should be aligned to the width of the edit texts
- one button should contains text "Login" and the other one "Register"
- Login button closes Login screen and open home screen of the app
- Register button displays toast with the following message "Registering users not supported"

## SOLUTION

## SCREENSHOTS
![Screenshot 2022-06-20 at 09 41 51](https://user-images.githubusercontent.com/32538721/174550314-aac0ba96-2e6c-4dfd-ba17-a3e98a3e6ea2.png)

## SIDE NOTES
<!-- More details that you think are important -->
