### PR TITLE
P2022-2212 Create dataBind variables that holds response after valida…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,7 @@ android {
     }
     buildFeatures {
         viewBinding true
+        dataBinding true
     }
 }
 
@@ -60,8 +61,8 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation 'com.google.code.gson:gson:2.8.9'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1'
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.4.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.0'
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.5.0'
     implementation 'com.github.bumptech.glide:glide:4.11.0'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
     implementation 'com.google.dagger:hilt-android:2.42'
@@ -86,4 +87,6 @@ dependencies {
 
     // Mockito
     testImplementation 'org.mockito.kotlin:mockito-kotlin:4.0.0'
+    testImplementation "org.mockito:mockito-inline:3.11.2"
+    testImplementation 'androidx.arch.core:core-testing:2.1.0'
 }

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/register/RegisterFragment.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/register/RegisterFragment.kt
@@ -4,18 +4,65 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import com.intive.patronage22.lublin.databinding.FragmentRegisterBinding
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class RegisterFragment : Fragment() {
+
+    private var _binding: FragmentRegisterBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: RegisterViewModel by viewModels()
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val binding = FragmentRegisterBinding.inflate(inflater, container, false)
+        _binding = FragmentRegisterBinding.inflate(inflater, container, false)
+        binding.registerViewModel = viewModel
+        binding.lifecycleOwner = this
+
+        registerUsernameOnFocusChange(binding.editTextUsername)
+        registerPasswordOnFocusChange(binding.editTextPassword)
+        registerEmailOnFocusChange(binding.editTextEmail)
+
         return binding.root
+    }
+
+    private fun registerUsernameOnFocusChange(editText: EditText) {
+        editText.setOnFocusChangeListener { _, hasFocus ->
+            if (!hasFocus) {
+                viewModel.onUsernameChanged(editText.text.toString())
+            }
+        }
+    }
+
+    private fun registerPasswordOnFocusChange(editText: EditText) {
+        editText.setOnFocusChangeListener { _, hasFocus ->
+            if (!hasFocus) {
+                viewModel.onPasswordChanged(editText.text.toString())
+            }
+        }
+    }
+
+    private fun registerEmailOnFocusChange(editText: EditText) {
+        editText.setOnFocusChangeListener { _, hasFocus ->
+            if (!hasFocus) {
+                viewModel.onEmailChanged(editText.text.toString())
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        binding.editTextUsername.onFocusChangeListener = null
+        binding.editTextEmail.onFocusChangeListener = null
+        binding.editTextPassword.onFocusChangeListener = null
+        _binding = null
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/register/RegisterViewModel.kt
@@ -1,8 +1,35 @@
 package com.intive.patronage22.lublin.screens.register
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.intive.patronage22.lublin.RegisterFlowValidator
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
-class RegisterViewModel @Inject constructor() : ViewModel()
+class RegisterViewModel @Inject constructor(
+    private val registerFlowValidator: RegisterFlowValidator
+) : ViewModel() {
+
+    private val _usernameValidationResult = MutableLiveData<String>()
+    val usernameValidationResult: LiveData<String> = _usernameValidationResult
+
+    private val _passwordValidationResult = MutableLiveData<String>()
+    val passwordValidationResult: LiveData<String> = _passwordValidationResult
+
+    private val _emailValidationResult = MutableLiveData<String>()
+    val emailValidationResult: LiveData<String> = _emailValidationResult
+
+    fun onUsernameChanged(username: String) {
+        _usernameValidationResult.value = registerFlowValidator.validateUsername(username)
+    }
+
+    fun onPasswordChanged(password: String) {
+        _passwordValidationResult.value = registerFlowValidator.validatePassword(password)
+    }
+
+    fun onEmailChanged(email: String) {
+        _emailValidationResult.value = registerFlowValidator.validateEmail(email)
+    }
+}

--- a/app/src/main/java/com/intive/patronage22/lublin/ui/base/ViewExtensions.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/ui/base/ViewExtensions.kt
@@ -1,0 +1,9 @@
+package com.intive.patronage22.lublin.ui.base
+
+import androidx.databinding.BindingAdapter
+import com.google.android.material.textfield.TextInputLayout
+
+@BindingAdapter("app:errorText")
+fun TextInputLayout.setErrorMessage(errorMessage: String?) {
+    this.error = errorMessage
+}

--- a/app/src/main/res/layout/fragment_register.xml
+++ b/app/src/main/res/layout/fragment_register.xml
@@ -1,83 +1,98 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<layout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <Button
-        android:id="@+id/registerButton"
-        android:layout_width="200sp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="25dp"
-        android:text="@string/register_button_text"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/emailTextInputLayout" />
+    <data>
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/usernameTextInputLayout"
+        <variable
+            name="registerViewModel"
+            type="com.intive.patronage22.lublin.screens.register.RegisterViewModel" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="250dp"
-        android:foregroundGravity="center_horizontal"
-        android:gravity="center_vertical"
-        app:errorEnabled="true"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_height="match_parent">
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/editTextUsername"
-            android:layout_width="200sp"
+        <Button
+            android:id="@+id/registerButton"
+            android:layout_width="@dimen/edit_text_width"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:ems="10"
-            android:hint="@string/username_hint"
-            android:inputType="textPersonName"
-            android:minHeight="48dp" />
-    </com.google.android.material.textfield.TextInputLayout>
+            android:layout_marginTop="25dp"
+            android:text="@string/register_button_text"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/emailTextInputLayout" />
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/passwordTextInputLayout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:errorEnabled="true"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/usernameTextInputLayout">
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/editTextPassword"
-            android:layout_width="200sp"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/usernameTextInputLayout"
+            android:layout_width="@dimen/edit_text_width"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:ems="10"
-            android:hint="@string/password_hint"
-            android:inputType="textPassword"
-            android:minHeight="48dp" />
+            android:layout_marginTop="250dp"
+            android:foregroundGravity="center_horizontal"
+            android:gravity="center_vertical"
+            android:textAlignment="gravity"
+            app:errorEnabled="true"
+            app:errorText="@{registerViewModel.usernameValidationResult}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-    </com.google.android.material.textfield.TextInputLayout>
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextUsername"
+                android:layout_width="@dimen/edit_text_width"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:ems="10"
+                android:hint="@string/username_hint"
+                android:inputType="textPersonName"
+                android:minHeight="48dp" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/emailTextInputLayout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:errorEnabled="true"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/passwordTextInputLayout">
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/editTextEmail"
-            android:layout_width="200sp"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/passwordTextInputLayout"
+            android:layout_width="@dimen/edit_text_width"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:ems="10"
-            android:hint="@string/email_hint"
-            android:inputType="textPersonName"
-            android:minHeight="48dp" />
+            app:errorEnabled="true"
+            app:errorText="@{registerViewModel.passwordValidationResult}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/usernameTextInputLayout">
 
-    </com.google.android.material.textfield.TextInputLayout>
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextPassword"
+                android:layout_width="@dimen/edit_text_width"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:ems="10"
+                android:hint="@string/password_hint"
+                android:inputType="textPassword"
+                android:minHeight="48dp" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/emailTextInputLayout"
+            android:layout_width="@dimen/edit_text_width"
+            android:layout_height="wrap_content"
+            app:errorEnabled="true"
+            app:errorText="@{registerViewModel.emailValidationResult}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/passwordTextInputLayout">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextEmail"
+                android:layout_width="@dimen/edit_text_width"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:ems="10"
+                android:hint="@string/email_hint"
+                android:inputType="textPersonName"
+                android:minHeight="48dp" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,3 +1,4 @@
 <resources>
     <dimen name="fab_margin">16dp</dimen>
+    <dimen name="edit_text_width">200dp</dimen>
 </resources>

--- a/app/src/test/java/com/intive/patronage22/lublin/screens/register/RegisterViewModelTest.kt
+++ b/app/src/test/java/com/intive/patronage22/lublin/screens/register/RegisterViewModelTest.kt
@@ -1,0 +1,49 @@
+package com.intive.patronage22.lublin.screens.register
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.intive.patronage22.lublin.RegisterFlowValidator
+import org.amshove.kluent.`should be`
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+class RegisterViewModelTest {
+
+    private val validationResult = "validation result"
+    private val username = "username"
+    private val password = "password"
+    private val email = "email"
+
+    private val tested by lazy { RegisterViewModel(validator) }
+
+    private val validator: RegisterFlowValidator = mock {
+        on { validateUsername(username) } doReturn validationResult
+        on { validatePassword(password) } doReturn validationResult
+        on { validateEmail(email) } doReturn validationResult
+    }
+
+    @get:Rule
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    @Test
+    fun `given username when onUsernameChanged called then return validation result`() {
+        tested.onUsernameChanged(username)
+
+        tested.usernameValidationResult.value `should be` "validation result"
+    }
+
+    @Test
+    fun `given password when onPasswordChanged called then return validation result`() {
+        tested.onPasswordChanged(password)
+
+        tested.passwordValidationResult.value `should be` "validation result"
+    }
+
+    @Test
+    fun `given email when onEmailChanged called then return validation result`() {
+        tested.onEmailChanged(email)
+
+        tested.emailValidationResult.value `should be` "validation result"
+    }
+}


### PR DESCRIPTION
# [P2022-2212](https://tracker.intive.com/jira/browse/P2022-2212)

## PROBLEM
AC:
- fields should contain corresponding errors messages if applicable
- use validator to check input from user.

## SOLUTION

- Connect data between ViewModel and xml by Data Bidinig. 
- Biding adapter needed when setting error text after validation in xml.
- Responses are hold in MutableLiveData exposed in LiveData.
- [P2022-2216](https://tracker.intive.com/jira/browse/P2022-2216) set listeners to null onDestroy.
- Cover ViewModel with Tests.


## SCREENSHOTS
![Screenshot 2022-07-05 at 10 01 47](https://user-images.githubusercontent.com/32538721/177280389-7c941f85-b922-4972-9e01-545ed0ad900b.png)

## SIDE NOTES
Register button will be finished in [P2022-2215](https://tracker.intive.com/jira/browse/P2022-2215)
Secure memory leak [P2022-2216](https://tracker.intive.com/jira/browse/P2022-2216) 