### PR TITLE
P2022-2215 Change button properties when disabled and add function to…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     // For local unit tests
     testImplementation 'com.google.dagger:hilt-android-testing:2.42'
     kaptTest 'com.google.dagger:hilt-compiler:2.42'
+    testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
 
     // for JVM:
     testImplementation 'org.amshove.kluent:kluent:1.68'

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/register/RegisterFragment.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/register/RegisterFragment.kt
@@ -5,8 +5,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
+import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.intive.patronage22.lublin.R
 import com.intive.patronage22.lublin.databinding.FragmentRegisterBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -27,35 +30,42 @@ class RegisterFragment : Fragment() {
         binding.registerViewModel = viewModel
         binding.lifecycleOwner = this
 
-        registerUsernameOnFocusChange(binding.editTextUsername)
-        registerPasswordOnFocusChange(binding.editTextPassword)
-        registerEmailOnFocusChange(binding.editTextEmail)
+        startListenUsername(binding.editTextUsername)
+        startListenPassword(binding.editTextPassword)
+        startListenEmail(binding.editTextEmail)
+
+        binding.registerButton.setOnClickListener {
+            this.findNavController().navigate(R.id.loginFragment)
+        }
 
         return binding.root
     }
 
-    private fun registerUsernameOnFocusChange(editText: EditText) {
+    private fun startListenUsername(editText: EditText) {
         editText.setOnFocusChangeListener { _, hasFocus ->
             if (!hasFocus) {
                 viewModel.onUsernameChanged(editText.text.toString())
             }
         }
+        editText.doAfterTextChanged { viewModel.onUsernameChanged(editText.text.toString()) }
     }
 
-    private fun registerPasswordOnFocusChange(editText: EditText) {
+    private fun startListenPassword(editText: EditText) {
         editText.setOnFocusChangeListener { _, hasFocus ->
             if (!hasFocus) {
                 viewModel.onPasswordChanged(editText.text.toString())
             }
         }
+        editText.doAfterTextChanged { viewModel.onPasswordChanged(editText.text.toString()) }
     }
 
-    private fun registerEmailOnFocusChange(editText: EditText) {
+    private fun startListenEmail(editText: EditText) {
         editText.setOnFocusChangeListener { _, hasFocus ->
             if (!hasFocus) {
                 viewModel.onEmailChanged(editText.text.toString())
             }
         }
+        editText.doAfterTextChanged { viewModel.onEmailChanged(editText.text.toString()) }
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/register/RegisterViewModel.kt
@@ -31,22 +31,22 @@ class RegisterViewModel @Inject constructor(
     fun onUsernameChanged(username: String) {
         _usernameValidationResult.value = registerFlowValidator.validateUsername(username)
         usernameCorrect = _usernameValidationResult.value == null
-        registerFormCorrect()
+        enableRegisterButton()
     }
 
     fun onPasswordChanged(password: String) {
         _passwordValidationResult.value = registerFlowValidator.validatePassword(password)
         passwordCorrect = _passwordValidationResult.value == null
-        registerFormCorrect()
+        enableRegisterButton()
     }
 
     fun onEmailChanged(email: String) {
         _emailValidationResult.value = registerFlowValidator.validateEmail(email)
         emailCorrect = emailValidationResult.value == null
-        registerFormCorrect()
+        enableRegisterButton()
     }
 
-    private fun registerFormCorrect() {
+    private fun enableRegisterButton() {
         _registerButtonEnabled.value = emailCorrect && usernameCorrect && passwordCorrect
     }
 }

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/register/RegisterViewModel.kt
@@ -12,6 +12,13 @@ class RegisterViewModel @Inject constructor(
     private val registerFlowValidator: RegisterFlowValidator
 ) : ViewModel() {
 
+    private var usernameCorrect = false
+    private var passwordCorrect = false
+    private var emailCorrect = false
+
+    private var _registerButtonEnabled = MutableLiveData<Boolean>(false)
+    val registerButtonEnabled: LiveData<Boolean> = _registerButtonEnabled
+
     private val _usernameValidationResult = MutableLiveData<String>()
     val usernameValidationResult: LiveData<String> = _usernameValidationResult
 
@@ -23,13 +30,23 @@ class RegisterViewModel @Inject constructor(
 
     fun onUsernameChanged(username: String) {
         _usernameValidationResult.value = registerFlowValidator.validateUsername(username)
+        usernameCorrect = _usernameValidationResult.value == null
+        registerFormCorrect()
     }
 
     fun onPasswordChanged(password: String) {
         _passwordValidationResult.value = registerFlowValidator.validatePassword(password)
+        passwordCorrect = _passwordValidationResult.value == null
+        registerFormCorrect()
     }
 
     fun onEmailChanged(email: String) {
         _emailValidationResult.value = registerFlowValidator.validateEmail(email)
+        emailCorrect = emailValidationResult.value == null
+        registerFormCorrect()
+    }
+
+    private fun registerFormCorrect() {
+        _registerButtonEnabled.value = emailCorrect && usernameCorrect && passwordCorrect
     }
 }

--- a/app/src/main/res/layout/fragment_register.xml
+++ b/app/src/main/res/layout/fragment_register.xml
@@ -17,6 +17,8 @@
 
         <Button
             android:id="@+id/registerButton"
+            style="@style/Widget.AppCompat.Button.Colored"
+            android:enabled="@{registerViewModel.registerButtonEnabled}"
             android:layout_width="@dimen/edit_text_width"
             android:layout_height="wrap_content"
             android:layout_marginTop="25dp"

--- a/app/src/test/java/com/intive/patronage22/lublin/FormValidationResults.kt
+++ b/app/src/test/java/com/intive/patronage22/lublin/FormValidationResults.kt
@@ -1,4 +1,4 @@
-package com.intive.patronage22.lublin.screens.register
+package com.intive.patronage22.lublin
 
 data class FormValidationResults(
     val correctUsername: String? = null,

--- a/app/src/test/java/com/intive/patronage22/lublin/screens/register/FormValidationResults.kt
+++ b/app/src/test/java/com/intive/patronage22/lublin/screens/register/FormValidationResults.kt
@@ -1,0 +1,12 @@
+package com.intive.patronage22.lublin.screens.register
+
+data class FormValidationResults(
+    val correctUsername: String? = null,
+    val correctPassword: String? = null,
+    val correctEmail: String? = null,
+    val incorrectUsername: String? = "error message",
+    val incorrectPassword: String? = "error message",
+    val incorrectEmail: String? = "error message",
+    val buttonEnabled: Boolean = true,
+    val buttonDisabled: Boolean = false
+)

--- a/app/src/test/java/com/intive/patronage22/lublin/screens/register/RegisterViewModelTest.kt
+++ b/app/src/test/java/com/intive/patronage22/lublin/screens/register/RegisterViewModelTest.kt
@@ -2,20 +2,28 @@ package com.intive.patronage22.lublin.screens.register
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.intive.patronage22.lublin.RegisterFlowValidator
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
+import junitparams.naming.TestCaseName
 import org.amshove.kluent.`should be`
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
+@RunWith(JUnitParamsRunner::class)
 class RegisterViewModelTest {
 
+    @get:Rule
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    private val f: FormValidationResults = FormValidationResults()
     private val validationResult = "validation result"
     private val username = "username"
     private val password = "password"
     private val email = "email"
-
-    private val tested by lazy { RegisterViewModel(validator) }
 
     private val validator: RegisterFlowValidator = mock {
         on { validateUsername(username) } doReturn validationResult
@@ -23,8 +31,7 @@ class RegisterViewModelTest {
         on { validateEmail(email) } doReturn validationResult
     }
 
-    @get:Rule
-    val instantExecutorRule = InstantTaskExecutorRule()
+    private val tested by lazy { RegisterViewModel(validator) }
 
     @Test
     fun `given username when onUsernameChanged called then return validation result`() {
@@ -46,4 +53,38 @@ class RegisterViewModelTest {
 
         tested.emailValidationResult.value `should be` "validation result"
     }
+
+    @Test
+    fun `given states when registerFormCorrect then verify result`() {
+        tested.registerButtonEnabled.value
+    }
+
+    @Test
+    @Parameters(method = "inputCorrectState")
+    @TestCaseName("given usernameValidationResult = {0}, emailValidationResult = {1}, passwordValidationResult = {2} when form validated then registerButtonEnabled = {3}")
+    fun `given state when registerFormCorrect then verify result`(
+        usernameValidationResult: String?,
+        emailValidationResult: String?,
+        passwordValidationResult: String?,
+        result: String?
+    ) {
+        whenever(validator.validateEmail(email)).doReturn(emailValidationResult)
+        whenever(validator.validatePassword(password)).doReturn(passwordValidationResult)
+        whenever(validator.validateUsername(username)).doReturn(usernameValidationResult)
+
+        tested.onEmailChanged(email)
+        tested.onPasswordChanged(password)
+        tested.onUsernameChanged(username)
+
+        tested.registerButtonEnabled.value `should be` result.toBoolean()
+    }
+
+    @Suppress("")
+    private fun inputCorrectState() = listOf(
+        arrayOf(f.correctUsername, f.correctEmail, f.correctPassword, f.buttonEnabled),
+        arrayOf(f.incorrectUsername, f.correctEmail, f.correctPassword, f.buttonDisabled),
+        arrayOf(f.correctUsername, f.incorrectEmail, f.correctPassword, f.buttonDisabled),
+        arrayOf(f.correctUsername, f.correctEmail, f.incorrectPassword, f.buttonDisabled),
+        arrayOf(f.incorrectUsername, f.incorrectEmail, f.incorrectPassword, f.buttonDisabled)
+    )
 }

--- a/app/src/test/java/com/intive/patronage22/lublin/screens/register/RegisterViewModelTest.kt
+++ b/app/src/test/java/com/intive/patronage22/lublin/screens/register/RegisterViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.intive.patronage22.lublin.screens.register
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.intive.patronage22.lublin.FormValidationResults
 import com.intive.patronage22.lublin.RegisterFlowValidator
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
@@ -19,7 +20,7 @@ class RegisterViewModelTest {
     @get:Rule
     val instantExecutorRule = InstantTaskExecutorRule()
 
-    private val f: FormValidationResults = FormValidationResults()
+    private val formValidationResults: FormValidationResults = FormValidationResults()
     private val validationResult = "validation result"
     private val username = "username"
     private val password = "password"
@@ -55,14 +56,9 @@ class RegisterViewModelTest {
     }
 
     @Test
-    fun `given states when registerFormCorrect then verify result`() {
-        tested.registerButtonEnabled.value
-    }
-
-    @Test
-    @Parameters(method = "inputCorrectState")
+    @Parameters(method = "testParams")
     @TestCaseName("given usernameValidationResult = {0}, emailValidationResult = {1}, passwordValidationResult = {2} when form validated then registerButtonEnabled = {3}")
-    fun `given state when registerFormCorrect then verify result`(
+    fun `given validation results when registration form fields changes then registration button has proper state`(
         usernameValidationResult: String?,
         emailValidationResult: String?,
         passwordValidationResult: String?,
@@ -79,12 +75,14 @@ class RegisterViewModelTest {
         tested.registerButtonEnabled.value `should be` result.toBoolean()
     }
 
-    @Suppress("")
-    private fun inputCorrectState() = listOf(
-        arrayOf(f.correctUsername, f.correctEmail, f.correctPassword, f.buttonEnabled),
-        arrayOf(f.incorrectUsername, f.correctEmail, f.correctPassword, f.buttonDisabled),
-        arrayOf(f.correctUsername, f.incorrectEmail, f.correctPassword, f.buttonDisabled),
-        arrayOf(f.correctUsername, f.correctEmail, f.incorrectPassword, f.buttonDisabled),
-        arrayOf(f.incorrectUsername, f.incorrectEmail, f.incorrectPassword, f.buttonDisabled)
-    )
+    private fun testParams() =
+        with(formValidationResults) {
+            listOf(
+                arrayOf(correctUsername, correctEmail, correctPassword, buttonEnabled),
+                arrayOf(incorrectUsername, correctEmail, correctPassword, buttonDisabled),
+                arrayOf(correctUsername, incorrectEmail, correctPassword, buttonDisabled),
+                arrayOf(correctUsername, correctEmail, incorrectPassword, buttonDisabled),
+                arrayOf(incorrectUsername, incorrectEmail, incorrectPassword, buttonDisabled)
+            )
+        }
 }


### PR DESCRIPTION
# [P2022-2215](https://tracker.intive.com/jira/browse/P2022-2215)

## PROBLEM

- register button takes the user to the login screen after validating the text fields
- register button should be disabled with visual indication until all validations are met
Validation of fields should be performed dynamically while entering and after changing the field.

## SOLUTION
add two listeners to edit text fields that check if input is valid to unlock button

## SCREENSHOTS
![Screenshot 2022-07-08 at 10 59 52](https://user-images.githubusercontent.com/32538721/177957045-0b510fc4-c449-4ae0-af15-a060e54f48b6.png)

## SIDE NOTES
On focus listener provide: when changed focus and left blank edit text ensure that the field will show error message.
Text watcher provides that when text is changed dynamically from correct form to incorrect, button will change to be disabled.