### PR TITLE
P2022-2218 Create Post method for register user with body as data cla…

### DIFF
--- a/app/src/main/java/com/intive/patronage22/lublin/RegisterFlowValidator.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/RegisterFlowValidator.kt
@@ -10,7 +10,7 @@ class RegisterFlowValidator @Inject constructor(@ApplicationContext var appConte
         Regex("[A-Za-zżźćńółęąśŻŹĆĄŚĘŁÓŃ0-9]+@[a-z]+\\.[a-z]+")
     private val passwordRegex =
         Regex(
-            "^(?=.+[0-9])(?=.+[A-Za-zżźćńółęąśŻŹĆĄŚĘŁÓŃ])(?=.+[@$!%*#?&])" +
+            "^(?=.+[0-9])(?=.+[A-Z])(?=.+[A-Za-zżźćńółęąśŻŹĆĄŚĘŁÓŃ])(?=.+[@$!%*#?&])" +
                     "[A-Za-zżźćńółęąśŻŹĆĄŚĘŁÓŃ0123456789@$!%*#?&]{6,}\$"
         )
     private val usernameRegex =

--- a/app/src/main/java/com/intive/patronage22/lublin/data/api/PatronageService.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/data/api/PatronageService.kt
@@ -2,7 +2,12 @@ package com.intive.patronage22.lublin.data.api
 
 import com.intive.patronage22.lublin.repository.model.CategoriesApi
 import com.intive.patronage22.lublin.repository.model.ProductApi
+import com.intive.patronage22.lublin.repository.model.RegisterResponseBody
+import com.intive.patronage22.lublin.repository.model.RegisterUserBody
+import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 
 interface PatronageService {
     @GET("products/getAllPublishedProductsExternal")
@@ -10,4 +15,9 @@ interface PatronageService {
 
     @GET("categories")
     suspend fun getAllCategories(): List<CategoriesApi>
+
+    @POST("auth/register")
+    suspend fun registerUser(
+        @Body registerUserBody: RegisterUserBody
+    ): Response<RegisterResponseBody>
 }

--- a/app/src/main/java/com/intive/patronage22/lublin/repository/model/RegisterResponseBody.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/repository/model/RegisterResponseBody.kt
@@ -1,0 +1,10 @@
+package com.intive.patronage22.lublin.repository.model
+
+import com.google.gson.annotations.SerializedName
+
+data class RegisterResponseBody(
+    @SerializedName("msg")
+    val msg: String?,
+    @SerializedName("token")
+    val token: String?
+)

--- a/app/src/main/java/com/intive/patronage22/lublin/repository/model/RegisterUserBody.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/repository/model/RegisterUserBody.kt
@@ -1,0 +1,12 @@
+package com.intive.patronage22.lublin.repository.model
+
+import com.google.gson.annotations.SerializedName
+
+data class RegisterUserBody(
+    @SerializedName("name")
+    val name: String,
+    @SerializedName("email")
+    val email: String,
+    @SerializedName("password")
+    val password: String
+)

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/register/RegisterFragment.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/register/RegisterFragment.kt
@@ -8,8 +8,6 @@ import android.widget.EditText
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.navigation.fragment.findNavController
-import com.intive.patronage22.lublin.R
 import com.intive.patronage22.lublin.databinding.FragmentRegisterBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -35,7 +33,11 @@ class RegisterFragment : Fragment() {
         startListenEmail(binding.editTextEmail)
 
         binding.registerButton.setOnClickListener {
-            this.findNavController().navigate(R.id.loginFragment)
+            viewModel.onRegisterButtonClicked(
+                binding.editTextUsername.text.toString(),
+                binding.editTextEmail.text.toString(),
+                binding.editTextPassword.text.toString()
+            )
         }
 
         return binding.root

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/register/RegisterViewModel.kt
@@ -3,13 +3,16 @@ package com.intive.patronage22.lublin.screens.register
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.intive.patronage22.lublin.RegisterFlowValidator
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class RegisterViewModel @Inject constructor(
-    private val registerFlowValidator: RegisterFlowValidator
+    private val registerFlowValidator: RegisterFlowValidator,
+    private val signUpUseCase: SignUpUseCase
 ) : ViewModel() {
 
     private val usernameCorrect: Boolean
@@ -50,5 +53,19 @@ class RegisterViewModel @Inject constructor(
 
     private fun enableRegisterButton() {
         _registerButtonEnabled.value = emailCorrect && usernameCorrect && passwordCorrect
+    }
+
+    fun onRegisterButtonClicked(name: String, email: String, password: String) {
+        registerUser(name, email, password)
+    }
+
+    private fun registerUser(
+        name: String,
+        email: String,
+        password: String
+    ) {
+        viewModelScope.launch {
+            signUpUseCase.execute(name, email, password)
+        }
     }
 }

--- a/app/src/main/java/com/intive/patronage22/lublin/screens/register/SignUpUseCase.kt
+++ b/app/src/main/java/com/intive/patronage22/lublin/screens/register/SignUpUseCase.kt
@@ -1,0 +1,18 @@
+package com.intive.patronage22.lublin.screens.register
+
+import com.intive.patronage22.lublin.data.api.PatronageService
+import com.intive.patronage22.lublin.repository.model.RegisterUserBody
+import javax.inject.Inject
+
+class SignUpUseCase @Inject constructor(
+    private val patronageService: PatronageService
+) {
+    suspend fun execute(
+        name: String,
+        email: String,
+        password: String
+    ) {
+        val registerUserBody = RegisterUserBody(name, email, password)
+        patronageService.registerUser(registerUserBody)
+    }
+}

--- a/app/src/test/java/com/intive/patronage22/lublin/RegisterFlowValidatorTest.kt
+++ b/app/src/test/java/com/intive/patronage22/lublin/RegisterFlowValidatorTest.kt
@@ -281,6 +281,26 @@ class RegisterFlowValidatorTest {
     }
 
     @Test
+    fun `given password with no uppercase characters when validatePassword then return proper message`() {
+        val noUpperPassword = "password123@!@#"
+        whenever(context.getString(R.string.not_valid_password_error)).doReturn("Enter a valid password")
+
+        val result = registerClass.validatePassword(noUpperPassword)
+
+        result `should be` "Enter a valid password"
+    }
+
+    @Test
+    fun `given password with no uppercase when validatePassword then request text from resources by proper resource id`() {
+        val noUpperPassword = "password123@!@#$"
+        whenever(context.getString(R.string.not_valid_password_error)).doReturn("Enter a valid password")
+
+        registerClass.validatePassword(noUpperPassword)
+
+        verify(context).getString(R.string.not_valid_password_error)
+    }
+
+    @Test
     fun `given correct password when validatePassword then return null`() {
         val correctPassword = "IamaGoodPAsswordś123@123$"
         whenever(context.getString(R.string.not_valid_password_error)).doReturn("Enter a valid password")

--- a/app/src/test/java/com/intive/patronage22/lublin/screens/register/RegisterViewModelTest.kt
+++ b/app/src/test/java/com/intive/patronage22/lublin/screens/register/RegisterViewModelTest.kt
@@ -32,8 +32,9 @@ class RegisterViewModelTest {
         on { validatePassword(password) } doReturn validationResult
         on { validateEmail(email) } doReturn validationResult
     }
+    private val signup: SignUpUseCase = mock()
 
-    private val tested by lazy { RegisterViewModel(validator) }
+    private val tested by lazy { RegisterViewModel(validator, signup) }
 
     @Test
     fun `given username when onUsernameChanged called then return validation result`() {


### PR DESCRIPTION
# [P2022-2218](https://tracker.intive.com/jira/browse/P2022-2218)

## PROBLEM
Implementation of a retrofit in the registration process

## SOLUTION
Sending request body with name, email and password from editText. 
Password validation from backend requires uppercase character in password -> add rule and test for it.

## SCREENSHOTS
![Screenshot 2022-07-20 at 12 15 24](https://user-images.githubusercontent.com/32538721/179958242-60e8fffd-f3aa-4359-b6f6-1c4655d16aa3.png)
![Screenshot 2022-07-20 at 12 15 05](https://user-images.githubusercontent.com/32538721/179958259-4ac3ebb7-33ba-42e6-9902-bb509f1d1416.png)


## SIDE NOTES
<!-- More details that you think are important -->
